### PR TITLE
add optional partition setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ server.register([
 - **host** - hostname or IP address of the Redis server
 - **port** - *(optional)* port of the Redis server; defaults to 6379
 - **varyByHeaders** - *(optional)* an array of headers to be used for generating cache key; defaults no none
+- **partition** - *(optional)* string to prefix cache keys with, useful for shared redis instances
 - **staleIn** - number of seconds until the cached response will be considered stale and marked for regeneration
 - **expiresIn** - number of seconds until the cached response will be purged from Redis
 - **onCacheMiss** - *(optional)* function which is invoked on each cache write; useful for tracking cache miss rates in a service

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -49,7 +49,7 @@ exports.register = function (plugin, options, next) {
             path    = req.url.path.toLowerCase(),
             headers = getWhitelistedHeaders(req.headers, options.varyByHeaders).join('&');
 
-        return method + '|' + path + '|' + headers;
+        return [options.partition, method, path, headers].join('|');
     };
 
     plugin.ext('onPreHandler', function(req, reply) {

--- a/src/schema.js
+++ b/src/schema.js
@@ -6,6 +6,7 @@ module.exports = {
     host: joi.string().required(),
     port: joi.number().min(1),
     varyByHeaders: joi.array(),
+    partition: joi.string(),
     staleIn: joi.number().min(1).required(),
     expiresIn: joi.number().min(1).required(),
     onCacheMiss: joi.func(),

--- a/test/plugin (cold cache, failed GET request).js
+++ b/test/plugin (cold cache, failed GET request).js
@@ -77,7 +77,7 @@ describe('plugin (cold cache, successful GET request)', function() {
 
                 server.onPreResponse(req, {
                     'continue': function() {
-                        redis.get('get|/resources/1', function(err, data) {
+                        redis.get('|get|/resources/1', function(err, data) {
                             cachedResponse = data;
                             done();
                         });

--- a/test/plugin (cold cache, invalid GET request).js
+++ b/test/plugin (cold cache, invalid GET request).js
@@ -52,7 +52,7 @@ describe('plugin (cold cache, successful GET request)', function() {
 
                 server.onPreResponse(req, {
                     'continue': function() {
-                        redis.get('get|/resources/1', function(err, data) {
+                        redis.get('|get|/resources/1', function(err, data) {
                             cachedResponse = data;
                             done();
                         });

--- a/test/plugin (cold cache, non-cacheable GET request).js
+++ b/test/plugin (cold cache, non-cacheable GET request).js
@@ -82,7 +82,7 @@ describe('plugin (cold cache, non-cacheable GET request)', function() {
 
                 server.onPreResponse(req, {
                     'continue': function() {
-                        redis.get('get|/resources/1', function(err, data) {
+                        redis.get('|get|/resources/1', function(err, data) {
                             cachedResponse = data;
                             done();
                         });

--- a/test/plugin (cold cache, successful GET request).js
+++ b/test/plugin (cold cache, successful GET request).js
@@ -81,7 +81,7 @@ describe('plugin (cold cache, successful GET request)', function() {
 
                 server.onPreResponse(req, {
                     'continue': function() {
-                        redis.get('get|/resources/1|', function(err, data) {
+                        redis.get('|get|/resources/1|', function(err, data) {
                             cachedResponse = JSON.parse(data);
                             done();
                         });
@@ -90,7 +90,7 @@ describe('plugin (cold cache, successful GET request)', function() {
             });
 
             it('should set ttl on cache entry', function(done) {
-                redis.ttl('get|/resources/1|', function(err, data) {
+                redis.ttl('|get|/resources/1|', function(err, data) {
                     expect(data).to.equal(60);
                     done();
                 });

--- a/test/plugin (cold cache, successful POST request).js
+++ b/test/plugin (cold cache, successful POST request).js
@@ -81,7 +81,7 @@ describe('plugin (cold cache, successful POST request)', function() {
 
                 server.onPreResponse(req, {
                     'continue': function() {
-                        redis.get('post|/resources/1', function(err, data) {
+                        redis.get('|post|/resources/1', function(err, data) {
                             cachedResponse = data;
                             done();
                         });

--- a/test/plugin (stale cache, successful GET request).js
+++ b/test/plugin (stale cache, successful GET request).js
@@ -30,7 +30,7 @@ describe('plugin (stale cache, successful GET request)', function() {
     before(function(done) {
         redis.flushdb();
 
-        redis.set('get|/resources/1|', JSON.stringify({
+        redis.set('|get|/resources/1|', JSON.stringify({
             statusCode: 200,
             headers: { 'content-type': 'application/json' },
             payload: { test: true },
@@ -88,7 +88,7 @@ describe('plugin (stale cache, successful GET request)', function() {
 
                 server.onPreResponse(req, {
                     'continue': function() {
-                        redis.get('get|/resources/1|', function(err, data) {
+                        redis.get('|get|/resources/1|', function(err, data) {
                             cachedResponse = JSON.parse(data);
                             done();
                         });
@@ -97,7 +97,7 @@ describe('plugin (stale cache, successful GET request)', function() {
             });
 
             it('should set ttl on cache entry', function(done) {
-                redis.ttl('get|/resources/1|', function(err, data) {
+                redis.ttl('|get|/resources/1|', function(err, data) {
                     expect(data).to.equal(60);
                     done();
                 });

--- a/test/plugin (warm cache, successful GET request with non-whitelisted header).js
+++ b/test/plugin (warm cache, successful GET request with non-whitelisted header).js
@@ -34,7 +34,7 @@ describe('plugin (warm cache, successful GET request with non-whitelisted header
     before(function(done) {
         redis.flushdb();
 
-        redis.set('get|/resources/1|accept=application/json', JSON.stringify({
+        redis.set('|get|/resources/1|accept=application/json', JSON.stringify({
             statusCode: 200,
             headers: { 'content-type': 'application/json' },
             payload: { test: true },

--- a/test/plugin (warm cache, successful GET request).js
+++ b/test/plugin (warm cache, successful GET request).js
@@ -30,7 +30,7 @@ describe('plugin (warm cache, successful GET request)', function() {
     before(function(done) {
         redis.flushdb();
 
-        redis.set('get|/resources/1|', JSON.stringify({
+        redis.set('|get|/resources/1|', JSON.stringify({
             statusCode: 200,
             headers: { 'content-type': 'application/json' },
             payload: { test: true },

--- a/test/plugin option validation.js
+++ b/test/plugin option validation.js
@@ -75,4 +75,12 @@ describe('plugin option validation', function() {
             });
         });
     });
+
+    describe('given invalid partition', function() {
+        it('should return error', function () {
+            plugin.register(null, { host: '127.0.0.1', staleIn: 1, expiresIn: 1, partition: function(){} }, function(err) {
+                expect(err.toString()).to.equal('ValidationError: child "partition" fails because ["partition" must be a string]');
+            });
+        });
+    });
 });


### PR DESCRIPTION
Only downside to this is that when we roll it out it'll invalidate all existing cache-keys (since even if you don't set the partition, it still changes the key generation).

Personally I don't think that's terrible (we've done similar things before), but it's up to you. I find it useful to verify that your caches will regenerate properly.

If you want, I can add guard code to preserve the original key string when the partition is not set.