### PR TITLE
Plugin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,64 @@ server.register([
 - **onCacheMiss** - *(optional)* `function(request){ ... }` invoked on each cache write; useful for tracking cache miss rates in a service
 - **onError** - *(optional)* function which is invoked on each Redis error
 
+## Route Settings
+
+By default, output caching is disabled. To enable it for a specific route, set `cacheable: true` in the route settings:
+
+```
+server.route({
+    method: 'GET',
+    path: '/',
+    handler: function (request, reply) {
+        return reply('hello world');
+    },
+    config: {
+        plugins: {
+            'hapi-redis-output-cache': {
+                cacheable: true
+            }
+        }
+    }
+});
+```
+
+To enable for all routes, set `cacheable: true` in the server config:
+
+```
+var server = new (require('hapi').Server({
+    connections: {
+        routes: {
+            plugins: {
+                'hapi-redis-output-cache': {
+                    cacheable: true
+                }
+            }
+        }
+    }
+});
+````
+
+Additionally, you can override certain properties on a per-route basis:
+```
+server.route({
+    method: 'GET',
+    path: '/',
+    handler: function(request, reply){
+        return reply('hello world');
+    },
+    config: {
+        plugins: {
+            'hapi-redis-output-cache': {
+                cacheable: true,
+                staleIn: 60,
+                expiresIn: 120,
+                partition: 'foo'
+            }
+        }
+    }
+});
+```
+
 ## Miscellaneous
 Output cache metadata is injected into each request and can be access via `req.outputCache`:
 - **isStale**: boolean value indicating whether the cache is stale

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ server.route({
         plugins: {
             'hapi-redis-output-cache': {
                 cacheable: true,
+                varyByHeaders: ['accept-language'],
                 staleIn: 60,
                 expiresIn: 120,
                 partition: 'foo'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/ArnoldZokas/hapi-redis-output-cache",
   "dependencies": {
+    "hoek": "^2.12.0",
     "joi": "6.0.8",
     "redis": "0.12.1"
   },

--- a/test/plugin (cold cache, invalid GET request).js
+++ b/test/plugin (cold cache, invalid GET request).js
@@ -12,7 +12,10 @@ var requestPrototype = {
         route: {
             method: 'get',
             settings: {
-                handler: originalHandler
+                handler: originalHandler,
+                plugins: {
+                  'hapi-redis-output-cache': { cacheable: true }
+                }
             }
         },
         url: {

--- a/test/plugin (cold cache, non-cacheable GET request).js
+++ b/test/plugin (cold cache, non-cacheable GET request).js
@@ -13,7 +13,9 @@ var requestPrototype = {
             method: 'get',
             settings: {
                 handler: originalHandler,
-                tags: ['non-cacheable']
+                plugins: {
+                  'hapi-redis-output-cache': { cacheable: false }
+                }
             }
         },
         url: {

--- a/test/plugin (cold cache, successful GET request).js
+++ b/test/plugin (cold cache, successful GET request).js
@@ -12,7 +12,10 @@ var requestPrototype = {
         route: {
             method: 'get',
             settings: {
-                handler: originalHandler
+                handler: originalHandler,
+                plugins: {
+                  'hapi-redis-output-cache': { cacheable: true }
+                }
             }
         },
         url: {

--- a/test/plugin (cold cache, successful POST request).js
+++ b/test/plugin (cold cache, successful POST request).js
@@ -12,7 +12,10 @@ var requestPrototype = {
         route: {
             method: 'post',
             settings: {
-                handler: originalHandler
+                handler: originalHandler,
+                plugins: {
+                  'hapi-redis-output-cache': { cacheable: true }
+                }
             }
         },
         url: {

--- a/test/plugin (dead cache, successful GET request).js
+++ b/test/plugin (dead cache, successful GET request).js
@@ -12,7 +12,10 @@ var requestPrototype = {
         route: {
             method: 'get',
             settings: {
-                handler: originalHandler
+                handler: originalHandler,
+                plugins: {
+                  'hapi-redis-output-cache': { cacheable: true }
+                }
             }
         },
         url: {

--- a/test/plugin (missing route conf, GET request).js
+++ b/test/plugin (missing route conf, GET request).js
@@ -13,9 +13,7 @@ var requestPrototype = {
             method: 'get',
             settings: {
                 handler: originalHandler,
-                plugins: {
-                  'hapi-redis-output-cache': { cacheable: true }
-                }
+                plugins: {}
             }
         },
         url: {
@@ -29,7 +27,7 @@ var server = {
         }
     };
 
-describe('plugin (cold cache, successful GET request)', function() {
+describe('plugin (cold cache, non-cacheable GET request)', function() {
     before(function(done) {
         redis.flushdb();
 
@@ -76,7 +74,11 @@ describe('plugin (cold cache, successful GET request)', function() {
             var cachedResponse;
 
             before(function(done) {
-                req.response = {};
+                req.response = {
+                    statusCode: 200,
+                    headers: [{ 'content-type': 'application/json' }],
+                    source: { test: true }
+                };
 
                 server.onPreResponse(req, {
                     'continue': function() {

--- a/test/plugin (stale cache, successful GET request).js
+++ b/test/plugin (stale cache, successful GET request).js
@@ -12,7 +12,10 @@ var requestPrototype = {
         route: {
             method: 'get',
             settings: {
-                handler: originalHandler
+                handler: originalHandler,
+                plugins: {
+                  'hapi-redis-output-cache': { cacheable: true }
+                }
             }
         },
         url: {

--- a/test/plugin (warm cache, successful GET request with non-whitelisted header).js
+++ b/test/plugin (warm cache, successful GET request with non-whitelisted header).js
@@ -16,7 +16,10 @@ var requestPrototype = {
         route: {
             method: 'get',
             settings: {
-                handler: originalHandler
+                handler: originalHandler,
+                plugins: {
+                  'hapi-redis-output-cache': { cacheable: true }
+                }
             }
         },
         url: {

--- a/test/plugin (warm cache, successful GET request).js
+++ b/test/plugin (warm cache, successful GET request).js
@@ -12,7 +12,10 @@ var requestPrototype = {
         route: {
             method: 'get',
             settings: {
-                handler: originalHandler
+                handler: originalHandler,
+                plugins: {
+                  'hapi-redis-output-cache': { cacheable: true }
+                }
             }
         },
         url: {


### PR DESCRIPTION
Non-breaking changes:

- Override cache settings on a per route basis: `expiresIn`, `staleIn`, `partition`, `varyByHeader`

Breaking changes:

- Caching is disabled by default