### PR TITLE
Change to redis connection handling logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-redis-output-cache",
-  "version": "3.0.0-alpha.3",
+  "version": "3.0.0-alpha.4",
   "description": "Redis-backed output cache plugin for Hapi",
   "engines": {
     "node": ">=4.0.0",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -26,114 +26,116 @@ exports.register = function (plugin, options, next) {
     });
 
     client.on('ready', () => {
-        plugin.ext('onPreHandler', (req, reply) => {
-            const routeOptions = req.route.settings.plugins['hapi-redis-output-cache'] || {};
-            if(routeOptions.isCacheable !== true) {
-                return reply.continue();
-            }
+        plugin.log('cache', 'Connected.');
+    });
 
-            if(req.route.method !== 'get') {
-                return reply.continue();
-            }
+    plugin.ext('onPreHandler', (req, reply) => {
+        const routeOptions = req.route.settings.plugins['hapi-redis-output-cache'] || {};
+        if(routeOptions.isCacheable !== true) {
+            return reply.continue();
+        }
 
-            const cacheKey = cacheKeyGenerator.generateCacheKey(req, options);
+        if(req.route.method !== 'get') {
+            return reply.continue();
+        }
 
-            if(client.connected ) {
-                try {
-                    client.get(cacheKey, (err, data) => {
-                        if(err) {
-                            plugin.log('cache', options.error);
-                            return reply.continue();
-                        }
+        const cacheKey = cacheKeyGenerator.generateCacheKey(req, options);
 
-                        if(data) {
-                            const cachedValue = JSON.parse(data);
-                            req.outputCache = {
-                                data: cachedValue,
-                                isStale: true
-                            };
-
-                            const currentTime = Math.floor(new Date() / 1000);
-
-                            if(cachedValue.expiresOn > currentTime) {
-                                req.outputCache.isStale = false;
-
-                                const response = reply(cachedValue.payload);
-                                response.code(cachedValue.statusCode);
-
-                                const keys = Object.keys(cachedValue.headers);
-                                for(let i = 0; i < keys.length; i++) {
-                                    const key = keys[i];
-                                    response.header(key, cachedValue.headers[key]);
-                                }
-
-                                response.hold();
-                                response.send();
-                            }
-                        }
-
+        if(client.connected) {
+            try {
+                client.get(cacheKey, (err, data) => {
+                    if(err) {
+                        plugin.log('cache', options.error);
                         return reply.continue();
-                    });
-                } catch (err) {
-                    plugin.log('cache', `Unable to perform GET on ${options.host}:${options.port} for key ${cacheKey}. Redis returned: ${err}`);
-                    return reply.continue();
-                }
-            } else {
-                return reply.continue();
-            }
-        });
-
-        plugin.ext('onPreResponse', (req, reply) => {
-            const routeOptions = req.route.settings.plugins['hapi-redis-output-cache'] || {};
-            if(routeOptions.isCacheable !== true) {
-                return reply.continue();
-            }
-
-            if(req.route.method !== 'get') {
-                return reply.continue();
-            }
-
-            if(req.response.statusCode !== 200) {
-                if (req.response.statusCode >= 500 && req.response.statusCode < 600 && req.outputCache && req.outputCache.data) {
-                    req.response.statusCode = req.outputCache.data.statusCode;
-                    req.response.headers['content-type'] = 'application/json; charset=utf-8';
-
-                    const keys = Object.keys(req.outputCache.data.headers);
-                    for(let i = 0; i < keys.length; i++) {
-                        const key = keys[i];
-                        req.response.headers[key] = req.outputCache.data.headers[key];
                     }
 
-                    req.response.source = req.outputCache.data.payload;
-                }
+                    if(data) {
+                        const cachedValue = JSON.parse(data);
+                        req.outputCache = {
+                            data: cachedValue,
+                            isStale: true
+                        };
 
+                        const currentTime = Math.floor(new Date() / 1000);
+
+                        if(cachedValue.expiresOn > currentTime) {
+                            req.outputCache.isStale = false;
+
+                            const response = reply(cachedValue.payload);
+                            response.code(cachedValue.statusCode);
+
+                            const keys = Object.keys(cachedValue.headers);
+                            for(let i = 0; i < keys.length; i++) {
+                                const key = keys[i];
+                                response.header(key, cachedValue.headers[key]);
+                            }
+
+                            response.hold();
+                            response.send();
+                        }
+                    }
+
+                    return reply.continue();
+                });
+            } catch (err) {
+                plugin.log('cache', `Unable to perform GET on ${options.host}:${options.port} for key ${cacheKey}. Redis returned: ${err}`);
                 return reply.continue();
             }
+        } else {
+            return reply.continue();
+        }
+    });
 
-            if(req.outputCache && req.outputCache.isStale === false) {
-                return reply.continue();
-            }
+    plugin.ext('onPreResponse', (req, reply) => {
+        const routeOptions = req.route.settings.plugins['hapi-redis-output-cache'] || {};
+        if(routeOptions.isCacheable !== true) {
+            return reply.continue();
+        }
 
-            const cacheKey = cacheKeyGenerator.generateCacheKey(req, options);
+        if(req.route.method !== 'get') {
+            return reply.continue();
+        }
 
-            const cacheValue = {
-                statusCode: req.response.statusCode,
-                headers: req.response.headers,
-                payload: req.response.source,
-                expiresOn: Math.floor(new Date() / 1000) + options.staleIn
-            };
+        if(req.response.statusCode !== 200) {
+            if (req.response.statusCode >= 500 && req.response.statusCode < 600 && req.outputCache && req.outputCache.data) {
+                req.response.statusCode = req.outputCache.data.statusCode;
+                req.response.headers['content-type'] = 'application/json; charset=utf-8';
 
-            if(client.connected ) {
-                try {
-                    client.setex(cacheKey, options.expiresIn, JSON.stringify(cacheValue));
-                    options.onCacheMiss(req, reply);
-                } catch (err) {
-                    plugin.log('cache', `Unable to perform SETEX on ${options.host}:${options.port} for key ${cacheKey}. Redis returned: ${err}`);
+                const keys = Object.keys(req.outputCache.data.headers);
+                for(let i = 0; i < keys.length; i++) {
+                    const key = keys[i];
+                    req.response.headers[key] = req.outputCache.data.headers[key];
                 }
+
+                req.response.source = req.outputCache.data.payload;
             }
 
             return reply.continue();
-        });
+        }
+
+        if(req.outputCache && req.outputCache.isStale === false) {
+            return reply.continue();
+        }
+
+        const cacheKey = cacheKeyGenerator.generateCacheKey(req, options);
+
+        const cacheValue = {
+            statusCode: req.response.statusCode,
+            headers: req.response.headers,
+            payload: req.response.source,
+            expiresOn: Math.floor(new Date() / 1000) + options.staleIn
+        };
+
+        if(client.connected) {
+            try {
+                client.setex(cacheKey, options.expiresIn, JSON.stringify(cacheValue));
+                options.onCacheMiss(req, reply);
+            } catch (err) {
+                plugin.log('cache', `Unable to perform SETEX on ${options.host}:${options.port} for key ${cacheKey}. Redis returned: ${err}`);
+            }
+        }
+
+        return reply.continue();
     });
 
     next();

--- a/test/plugin attributes.js
+++ b/test/plugin attributes.js
@@ -9,6 +9,6 @@ describe('plugin attributes', () => {
     });
 
     it('should contain version', () => {
-        expect(plugin.register.attributes.version).to.equal('3.0.0-alpha.3');
+        expect(plugin.register.attributes.version).to.equal('3.0.0-alpha.4');
     });
 });


### PR DESCRIPTION
A better diff of this PR can be viewed with the link: https://github.com/ArnoldZokas/hapi-redis-output-cache/pull/10/files?w=1

This PR moves the registration of the `onPreHandler` and `onPreResponse` handlers outside of the `client.on('ready',...` block. This is to ensure that the handlers are only registered once. Currently they can be registered multiple times (in the event of the redis connection being lost and re-established), which leads to them being executed multiple times for a request. 